### PR TITLE
user status changes

### DIFF
--- a/user.go
+++ b/user.go
@@ -9,14 +9,22 @@ import (
 	"gopkg.in/resty.v1"
 )
 
+type UserStatus string
+
+const (
+	StatusActive   UserStatus = "active"
+	StatusInactive UserStatus = "inactive"
+	StatusPending  UserStatus = "pending"
+)
+
 type User struct {
-	ID            string    `json:"id"`
-	Active        bool      `json:"active"`
-	Email         string    `json:"email"`
-	Phone         string    `json:"phone"`
-	EmailVerified bool      `json:"email_verified"`
-	CreatedAt     time.Time `json:"created_at"`
-	LastLogin     time.Time `json:"last_login_at"`
+	ID            string     `json:"id"`
+	Status        UserStatus `json:"status"`
+	Email         string     `json:"email"`
+	Phone         string     `json:"phone"`
+	EmailVerified bool       `json:"email_verified"`
+	CreatedAt     time.Time  `json:"created_at"`
+	LastLogin     time.Time  `json:"last_login_at"`
 }
 
 // GetUser gets a user using their userID

--- a/user_test.go
+++ b/user_test.go
@@ -17,17 +17,17 @@ var (
 	passageAppID  string
 	passageApiKey string
 	passageUserID string
-	randomEmail = generateRandomEmail(14)
-	createdUser passage.User
+	randomEmail   = generateRandomEmail(14)
+	createdUser   passage.User
 )
 
 func generateRandomEmail(prefixLength int) string {
 	n := prefixLength
-    randomChars := make([]byte, n)
-    if _, err := rand.Read(randomChars); err != nil {
-        panic(err)
-    }
-    email := fmt.Sprintf("%X@email.com", randomChars)
+	randomChars := make([]byte, n)
+	if _, err := rand.Read(randomChars); err != nil {
+		panic(err)
+	}
+	email := fmt.Sprintf("%X@email.com", randomChars)
 	return email
 }
 
@@ -58,7 +58,7 @@ func TestActivateUser(t *testing.T) {
 	user, err := psg.ActivateUser(passageUserID)
 	require.Nil(t, err)
 	assert.Equal(t, passageUserID, user.ID)
-	assert.Equal(t, true, user.Active)
+	assert.Equal(t, passage.StatusActive, user.Status)
 }
 func TestDeactivateUser(t *testing.T) {
 	psg, err := passage.New(passageAppID, &passage.Config{
@@ -69,7 +69,7 @@ func TestDeactivateUser(t *testing.T) {
 	user, err := psg.DeactivateUser(passageUserID)
 	require.Nil(t, err)
 	assert.Equal(t, passageUserID, user.ID)
-	assert.Equal(t, false, user.Active)
+	assert.Equal(t, passage.StatusInactive, user.Status)
 }
 
 func TestUpdateUser(t *testing.T) {


### PR DESCRIPTION
Changes to support this story that changes the "active" boolean field on a user to a more generic "status" field. 
https://app.shortcut.com/passage-identity/story/937/change-active-field-to-a-status-field-in-the-user-model

This is a breaking change. Test won't pass until backend is updated.