### PR TITLE
add LastLoginAt to device type

### DIFF
--- a/user.go
+++ b/user.go
@@ -29,12 +29,13 @@ type User struct {
 }
 
 type Device struct {
-	ID         string    `json:"id"`
-	CredID     string    `json:"cred_id"`
-	Name       string    `json:"friendly_name"`
-	UsageCount uint      `json:"usage_count"`
-	UpdatedAt  time.Time `json:"updated_at"`
-	CreatedAt  time.Time `json:"created_at"`
+	ID          string    `json:"id"`
+	CredID      string    `json:"cred_id"`
+	Name        string    `json:"friendly_name"`
+	UsageCount  uint      `json:"usage_count"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	CreatedAt   time.Time `json:"created_at"`
+	LastLoginAt time.Time `json:"last_login_at"`
 }
 
 // GetUser gets a user using their userID


### PR DESCRIPTION
### Overview of Changes in this PR

-   add `last_login_at` to device type

Before device names could be updated, the `updated_at` value indicated the last login.
Now it indicates the last login _or_ the last name change.

This new `last_login_at` value accurately reflects the last login, even after a device name change.
