### PR TITLE
PSG-956 - propogate Api Errors up with the new Error class

### DIFF
--- a/error.go
+++ b/error.go
@@ -13,8 +13,7 @@ type Error struct {
 }
 
 type HTTPError struct {
-	StatusText string `json:"status,omitempty"`
-	ErrorText  string `json:"error,omitempty"`
+	ErrorText string `json:"error,omitempty"`
 }
 
 func (e Error) Error() string {

--- a/error.go
+++ b/error.go
@@ -1,0 +1,38 @@
+package passage
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Error struct {
+	Message    string
+	StatusCode int
+	StatusText string
+	ErrorText  string
+}
+
+type HTTPError struct {
+	StatusText string `json:"status,omitempty"`
+	ErrorText  string `json:"error,omitempty"`
+}
+
+func (e Error) Error() string {
+	var ps strings.Builder
+	ps.WriteString("Passage Error - ")
+
+	if e.Message != "" {
+		fmt.Fprintf(&ps, "message: %s, ", e.Message)
+	}
+	if e.StatusCode != 0 {
+		fmt.Fprintf(&ps, "status_code: %v, ", e.StatusCode)
+	}
+	if e.StatusText != "" {
+		fmt.Fprintf(&ps, "status_text: %s, ", e.StatusText)
+	}
+	if e.ErrorText != "" {
+		fmt.Fprintf(&ps, "error: %s, ", e.ErrorText)
+	}
+
+	return strings.TrimSuffix(ps.String(), ", ")
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,30 @@
+package passage_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/passageidentity/passage-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorWithAllFields(t *testing.T) {
+	Error := passage.Error{
+		Message:    "some message",
+		StatusCode: http.StatusBadRequest,
+		StatusText: http.StatusText(http.StatusBadRequest),
+		ErrorText:  "some error",
+	}
+	errorString := Error.Error()
+	assert.Equal(t, "Passage Error - message: some message, status_code: 400, status_text: Bad Request, error: some error", errorString)
+
+}
+
+func TestErrorWithOnlyMessage(t *testing.T) {
+	Error := passage.Error{
+		Message: "some message",
+	}
+	errorString := Error.Error()
+	assert.Equal(t, "Passage Error - message: some message", errorString)
+
+}

--- a/user.go
+++ b/user.go
@@ -1,7 +1,6 @@
 package passage
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -46,19 +45,31 @@ func (a *App) GetUser(userID string) (*User, error) {
 		User User `json:"user"`
 	}
 	var userBody respUser
+	var errorResponse HTTPError
 
 	response, err := resty.New().R().
 		SetAuthToken(a.Config.APIKey).
 		SetResult(&userBody).
+		SetError(&errorResponse).
 		Get(fmt.Sprintf("https://api.passage.id/v1/apps/%v/users/%v", a.ID, userID))
 	if err != nil {
-		return nil, errors.New("network error: could not get Passage User")
+		return nil, Error{Message: "network error: failed to get Passage User"}
 	}
 	if response.StatusCode() == http.StatusNotFound {
-		return nil, fmt.Errorf("passage User with ID \"%v\" does not exist", userID)
+		return nil, Error{
+			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist", userID),
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 	if response.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("failed to get Passage User")
+		return nil, Error{
+			Message:    "failed to get Passage User",
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 	user := userBody.User
 
@@ -72,19 +83,31 @@ func (a *App) ActivateUser(userID string) (*User, error) {
 		User User `json:"user"`
 	}
 	var userBody respUser
+	var errorResponse HTTPError
 
 	response, err := resty.New().R().
 		SetAuthToken(a.Config.APIKey).
 		SetResult(&userBody).
+		SetError(&errorResponse).
 		Patch(fmt.Sprintf("https://api.passage.id/v1/apps/%v/users/%v/activate", a.ID, userID))
 	if err != nil {
-		return nil, errors.New("network error: could not get activate Passage User")
+		return nil, Error{Message: "network error: failed to get activate Passage User"}
 	}
 	if response.StatusCode() == http.StatusNotFound {
-		return nil, fmt.Errorf("passage User with ID \"%v\" does not exist", userID)
+		return nil, Error{
+			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist", userID),
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 	if response.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("failed to activate Passage User")
+		return nil, Error{
+			Message:    "failed to activate Passage User",
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 	user := userBody.User
 
@@ -98,19 +121,31 @@ func (a *App) DeactivateUser(userID string) (*User, error) {
 		User User `json:"user"`
 	}
 	var userBody respUser
+	var errorResponse HTTPError
 
 	response, err := resty.New().R().
 		SetAuthToken(a.Config.APIKey).
 		SetResult(&userBody).
+		SetBody(&errorResponse).
 		Patch(fmt.Sprintf("https://api.passage.id/v1/apps/%v/users/%v/deactivate", a.ID, userID))
 	if err != nil {
-		return nil, errors.New("network error: could not get deactivate Passage User")
+		return nil, Error{Message: "network error: failed to deactivate Passage User"}
 	}
 	if response.StatusCode() == http.StatusNotFound {
-		return nil, fmt.Errorf("passage User with ID \"%v\" does not exist", userID)
+		return nil, Error{
+			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist", userID),
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 	if response.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("failed to deactivate Passage User")
+		return nil, Error{
+			Message:    "failed to deactivate Passage User",
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 	user := userBody.User
 
@@ -131,20 +166,32 @@ func (a *App) UpdateUser(userID string, updateBody UpdateBody) (*User, error) {
 		User User `json:"user"`
 	}
 	var userBody respUser
+	var errorResponse HTTPError
 
 	response, err := resty.New().R().
 		SetAuthToken(a.Config.APIKey).
 		SetResult(&userBody).
 		SetBody(updateBody).
+		SetError(&errorResponse).
 		Patch(fmt.Sprintf("https://api.passage.id/v1/apps/%v/users/%v", a.ID, userID))
 	if err != nil {
-		return nil, errors.New("network error: could not update Passage User attributes")
+		return nil, Error{Message: "network error: failed to update Passage User attributes"}
 	}
 	if response.StatusCode() == http.StatusNotFound {
-		return nil, fmt.Errorf("passage User with ID \"%v\" does not exist", userID)
+		return nil, Error{
+			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist", userID),
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 	if response.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("failed to patch Passage User's attributes")
+		return nil, Error{
+			Message:    "failed to update Passage User's attributes",
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 	user := userBody.User
 
@@ -154,17 +201,31 @@ func (a *App) UpdateUser(userID string, updateBody UpdateBody) (*User, error) {
 // DeleteUser receives a userID (string), and deletes the corresponding user
 // returns true on success, false and error on failure (bool, err)
 func (a *App) DeleteUser(userID string) (bool, error) {
+
+	var errorResponse HTTPError
+
 	response, err := resty.New().R().
 		SetAuthToken(a.Config.APIKey).
+		SetError(&errorResponse).
 		Delete(fmt.Sprintf("https://api.passage.id/v1/apps/%v/users/%v", a.ID, userID))
 	if err != nil {
-		return false, errors.New("network error: could not delete Passage User")
+		return false, Error{Message: "network error: could not delete Passage User"}
 	}
 	if response.StatusCode() == http.StatusNotFound {
-		return false, fmt.Errorf("passage User with ID \"%v\" does not exist", userID)
+		return false, Error{
+			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist", userID),
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 	if response.StatusCode() != http.StatusOK {
-		return false, fmt.Errorf("failed to delete Passage User")
+		return false, Error{
+			Message:    "failed to delete Passage User",
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 
 	return true, nil
@@ -184,17 +245,24 @@ func (a *App) CreateUser(createUserBody CreateUserBody) (*User, error) {
 		User User `json:"user"`
 	}
 	var userBody respUser
+	var errorResponse HTTPError
 
 	response, err := resty.New().R().
 		SetResult(&userBody).
-		SetBody(createUserBody).
+		SetBody(&createUserBody).
+		SetError(&errorResponse).
 		SetAuthToken(a.Config.APIKey).
 		Post(fmt.Sprintf("https://api.passage.id/v1/apps/%v/users/", a.ID))
 	if err != nil {
-		return nil, errors.New("network error: could not create Passage User")
+		return nil, Error{Message: "network error: failed create Passage User"}
 	}
 	if response.StatusCode() != http.StatusCreated {
-		return nil, fmt.Errorf("failed to create Passage User. Http Status: %v. Response: %v", response.StatusCode(), response.String())
+		return nil, Error{
+			Message:    "failed to create Passage User",
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 	user := userBody.User
 
@@ -208,19 +276,31 @@ func (a *App) ListUserDevices(userID string) ([]Device, error) {
 		Devices []Device `json:"devices"`
 	}
 	var devicesBody respDevices
+	var errorResponse HTTPError
 
 	response, err := resty.New().R().
 		SetAuthToken(a.Config.APIKey).
 		SetResult(&devicesBody).
+		SetError(&errorResponse).
 		Get(fmt.Sprintf("https://api.passage.id/v1/apps/%v/users/%v/devices", a.ID, userID))
 	if err != nil {
-		return nil, errors.New("network error: could not get Passage User")
+		return nil, Error{Message: "network error: failed to list devices for a Passage User"}
 	}
 	if response.StatusCode() == http.StatusNotFound {
-		return nil, fmt.Errorf("passage User with ID \"%v\" does not exist", userID)
+		return nil, Error{
+			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist", userID),
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 	if response.StatusCode() != http.StatusOK {
-		return nil, fmt.Errorf("failed to list devices for a Passage User")
+		return nil, Error{
+			Message:    "failed to list devices for a Passage User",
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 	devices := devicesBody.Devices
 
@@ -230,17 +310,31 @@ func (a *App) ListUserDevices(userID string) ([]Device, error) {
 // RevokeUserDevice gets a user using their userID
 // returns a true success, error on failure
 func (a *App) RevokeUserDevice(userID, deviceID string) (bool, error) {
+
+	var errorResponse HTTPError
+
 	response, err := resty.New().R().
 		SetAuthToken(a.Config.APIKey).
+		SetError(&errorResponse).
 		Delete(fmt.Sprintf("https://api.passage.id/v1/apps/%v/users/%v/devices/%v", a.ID, userID, deviceID))
 	if err != nil {
-		return false, errors.New("network error: could not get Passage User")
+		return false, Error{Message: "network error: failed to delete a device for a Passage User"}
 	}
 	if response.StatusCode() == http.StatusNotFound {
-		return false, fmt.Errorf("passage User with ID \"%v\" does not exist or Devices with ID \"%v\" does not exist", userID, deviceID)
+		return false, Error{
+			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist or Devices with ID \"%v\" does not exist", userID, deviceID),
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 	if response.StatusCode() != http.StatusOK {
-		return false, fmt.Errorf("failed to delete a device for a Passage User")
+		return false, Error{
+			Message:    "failed to delete a device for a Passage User",
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 
 	return true, nil
@@ -249,17 +343,31 @@ func (a *App) RevokeUserDevice(userID, deviceID string) (bool, error) {
 // Signout revokes a users refresh tokens
 // returns true on success, error on failure
 func (a *App) SignOut(userID string) (bool, error) {
+
+	var errorResponse HTTPError
+
 	response, err := resty.New().R().
 		SetAuthToken(a.Config.APIKey).
+		SetError(&errorResponse).
 		Delete(fmt.Sprintf("https://api.passage.id/v1/apps/%v/users/%v/tokens/", a.ID, userID))
 	if err != nil {
-		return false, errors.New("network error: could not get Passage User")
+		return false, Error{Message: "network error: failed to revoke all refresh tokens for a Passage User"}
 	}
 	if response.StatusCode() == http.StatusNotFound {
-		return false, fmt.Errorf("passage User with ID \"%v\" does not exist", userID)
+		return false, Error{
+			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist", userID),
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 	if response.StatusCode() != http.StatusOK {
-		return false, fmt.Errorf("failed to revoke all refresh tokens for a Passage User")
+		return false, Error{
+			Message:    "failed to revoke all refresh tokens for a Passage User",
+			StatusCode: response.StatusCode(),
+			StatusText: http.StatusText(response.StatusCode()),
+			ErrorText:  errorResponse.ErrorText,
+		}
 	}
 
 	return true, nil

--- a/user.go
+++ b/user.go
@@ -11,9 +11,10 @@ import (
 type UserStatus string
 
 const (
-	StatusActive   UserStatus = "active"
-	StatusInactive UserStatus = "inactive"
-	StatusPending  UserStatus = "pending"
+	UserIDDoesNotExist string     = "passage User with ID \"%v\" does not exist"
+	StatusActive       UserStatus = "active"
+	StatusInactive     UserStatus = "inactive"
+	StatusPending      UserStatus = "pending"
 )
 
 type User struct {
@@ -57,7 +58,7 @@ func (a *App) GetUser(userID string) (*User, error) {
 	}
 	if response.StatusCode() == http.StatusNotFound {
 		return nil, Error{
-			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist", userID),
+			Message:    fmt.Sprintf(UserIDDoesNotExist, userID),
 			StatusCode: response.StatusCode(),
 			StatusText: http.StatusText(response.StatusCode()),
 			ErrorText:  errorResponse.ErrorText,
@@ -95,7 +96,7 @@ func (a *App) ActivateUser(userID string) (*User, error) {
 	}
 	if response.StatusCode() == http.StatusNotFound {
 		return nil, Error{
-			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist", userID),
+			Message:    fmt.Sprintf(UserIDDoesNotExist, userID),
 			StatusCode: response.StatusCode(),
 			StatusText: http.StatusText(response.StatusCode()),
 			ErrorText:  errorResponse.ErrorText,
@@ -133,7 +134,7 @@ func (a *App) DeactivateUser(userID string) (*User, error) {
 	}
 	if response.StatusCode() == http.StatusNotFound {
 		return nil, Error{
-			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist", userID),
+			Message:    fmt.Sprintf(UserIDDoesNotExist, userID),
 			StatusCode: response.StatusCode(),
 			StatusText: http.StatusText(response.StatusCode()),
 			ErrorText:  errorResponse.ErrorText,
@@ -179,7 +180,7 @@ func (a *App) UpdateUser(userID string, updateBody UpdateBody) (*User, error) {
 	}
 	if response.StatusCode() == http.StatusNotFound {
 		return nil, Error{
-			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist", userID),
+			Message:    fmt.Sprintf(UserIDDoesNotExist, userID),
 			StatusCode: response.StatusCode(),
 			StatusText: http.StatusText(response.StatusCode()),
 			ErrorText:  errorResponse.ErrorText,
@@ -213,7 +214,7 @@ func (a *App) DeleteUser(userID string) (bool, error) {
 	}
 	if response.StatusCode() == http.StatusNotFound {
 		return false, Error{
-			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist", userID),
+			Message:    fmt.Sprintf(UserIDDoesNotExist, userID),
 			StatusCode: response.StatusCode(),
 			StatusText: http.StatusText(response.StatusCode()),
 			ErrorText:  errorResponse.ErrorText,
@@ -288,7 +289,7 @@ func (a *App) ListUserDevices(userID string) ([]Device, error) {
 	}
 	if response.StatusCode() == http.StatusNotFound {
 		return nil, Error{
-			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist", userID),
+			Message:    fmt.Sprintf(UserIDDoesNotExist, userID),
 			StatusCode: response.StatusCode(),
 			StatusText: http.StatusText(response.StatusCode()),
 			ErrorText:  errorResponse.ErrorText,
@@ -355,7 +356,7 @@ func (a *App) SignOut(userID string) (bool, error) {
 	}
 	if response.StatusCode() == http.StatusNotFound {
 		return false, Error{
-			Message:    fmt.Sprintf("passage User with ID \"%v\" does not exist", userID),
+			Message:    fmt.Sprintf(UserIDDoesNotExist, userID),
 			StatusCode: response.StatusCode(),
 			StatusText: http.StatusText(response.StatusCode()),
 			ErrorText:  errorResponse.ErrorText,


### PR DESCRIPTION
Error struct now containes these fields:
`Message` -> descriptive information regarding the error from the sdk
`StatusCode` (optional) -> api status code from an API request to the passage backend
`StatusText` (optional) -> api status text from an API request to the passage backend
`ErrorText` (optional) -> api descriptive error from an API request to the passage backend