### PR TITLE
PSG-1047: fix release check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Read version
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Create Release
-        if: ${{ steps.check.outputs.create_release }}
+        if: ${{ steps.check.outputs.create_release == 'true' }}
         id: create_release
         uses: actions/create-release@v1
         with:


### PR DESCRIPTION
-   fetch history for all tags

This should fix the error in this run: https://github.com/passageidentity/passage-go/actions/runs/3191253225

Introduced in https://github.com/passageidentity/passage-go/pull/24.

A successful test run with a skipped release can be seen [here](https://github.com/passageidentity/passage-go/actions/runs/3191488469/jobs/5207861086).
