### PR TITLE
ci: pins gorename to v0.24.0

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -45,7 +45,7 @@ transforms='{
 }'
 
 # Function to perform replacements
-command -v gorename &> /dev/null || go install golang.org/x/tools/cmd/gorename@latest
+command -v gorename &> /dev/null || go install golang.org/x/tools/cmd/gorename@v0.24.0
 replace() {
     local in=$1 out=$2
     gorename -from "\"github.com/passageidentity/passage-go\".$in" -to "$out" -force


### PR DESCRIPTION
v0.25.0 is causing a failure in our upstream GHA:
>go: golang.org/x/tools/cmd/gorename@latest (in golang.org/x/tools@v0.25.0): go.mod:3: invalid go version '1.22.0': must match format 1.23

related GH issues:
* https://github.com/golang/go/issues/61888
* https://github.com/dominikh/go-tools/issues/1592