### PR TITLE
build: update renamed codegen types to be backwards-compatible

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -28,7 +28,8 @@ transforms='{
     "CreateMagicLinkRequest": "CreateMagicLinkBody",
     "CreateUserRequest": "CreateUserBody",
     "Inactive": "StatusInactive",
-    "Login": "LoginType",
+    "MagicLinkTypeLogin": "LoginType",
+    "MagicLinkTypeVerifyIdentifier": "VerifyIdentifierType",
     "MagicLinkChannel": "ChannelType",
     "MagicLinkChannelEmail": "EmailChannel",
     "MagicLinkChannelPhone": "PhoneChannel",
@@ -40,8 +41,7 @@ transforms='{
     "UserMetadataFieldTypeEmail": "EmailMD",
     "UserMetadataFieldTypeInteger": "IntegerMD",
     "UserMetadataFieldTypePhone": "PhoneMD",
-    "UserMetadataFieldTypeString": "StringMD",
-    "VerifyIdentifier": "VerifyIdentifierType"
+    "UserMetadataFieldTypeString": "StringMD"
 }'
 
 # Function to perform replacements


### PR DESCRIPTION
### Overview of Changes in this PR

-   update renamed codegen types to be backwards-compatible

This unblocks the workflow generating Go types from the Passage SDK spec.