### PR TITLE
refactor: PSG-5091  Remove JWK re-fetch logic

### DIFF
--- a/app.go
+++ b/app.go
@@ -46,6 +46,9 @@ func New(appID string, config *Config) (*App, error) {
 		return nil, err
 	}
 
+	app.jwksCacheSet = jwk.NewCachedSet(cache, fmt.Sprintf(jwksUrl, appID))
+	var _ jwk.Set = app.jwksCacheSet
+
 	return &app, nil
 }
 

--- a/app.go
+++ b/app.go
@@ -46,9 +46,6 @@ func New(appID string, config *Config) (*App, error) {
 		return nil, err
 	}
 
-	app.jwksCacheSet = jwk.NewCachedSet(cache, fmt.Sprintf(jwksUrl, appID))
-	var _ jwk.Set = app.jwksCacheSet
-
 	return &app, nil
 }
 

--- a/app.go
+++ b/app.go
@@ -41,16 +41,17 @@ func New(appID string, config *Config) (*App, error) {
 		client: client,
 	}
 
+	url := fmt.Sprintf(jwksUrl, appID)
 	cache := jwk.NewCache(context.Background())
-	if err := cache.Register(fmt.Sprintf(jwksUrl, appID)); err != nil {
+	if err := cache.Register(url); err != nil {
 		return nil, err
 	}
 
-	if _, err = cache.Refresh(context.Background(), fmt.Sprintf(jwksUrl, appID)); err != nil {
+	if _, err = cache.Refresh(context.Background(), url); err != nil {
 		return nil, Error{Message: "failed to fetch jwks"}
 	}
 
-	app.jwksCacheSet = jwk.NewCachedSet(cache, fmt.Sprintf(jwksUrl, appID))
+	app.jwksCacheSet = jwk.NewCachedSet(cache, url)
 
 	return &app, nil
 }

--- a/app.go
+++ b/app.go
@@ -46,8 +46,11 @@ func New(appID string, config *Config) (*App, error) {
 		return nil, err
 	}
 
+	if _, err = cache.Refresh(context.Background(), fmt.Sprintf(jwksUrl, appID)); err != nil {
+		return nil, Error{Message: "failed to fetch jwks"}
+	}
+
 	app.jwksCacheSet = jwk.NewCachedSet(cache, fmt.Sprintf(jwksUrl, appID))
-	var _ jwk.Set = app.jwksCacheSet
 
 	return &app, nil
 }

--- a/app.go
+++ b/app.go
@@ -15,11 +15,10 @@ type Config struct {
 }
 
 type App struct {
-	ID        string
-	JWKS      jwk.Set
-	Config    *Config
-	client    *ClientWithResponses
-	jwksCache *jwk.Cache
+	ID           string
+	Config       *Config
+	client       *ClientWithResponses
+	jwksCacheSet jwk.Set
 }
 
 func New(appID string, config *Config) (*App, error) {
@@ -42,14 +41,11 @@ func New(appID string, config *Config) (*App, error) {
 		client: client,
 	}
 
-	app.jwksCache = jwk.NewCache(context.Background())
-	if err := app.jwksCache.Register(fmt.Sprintf(jwksUrl, appID)); err != nil {
+	cache := jwk.NewCache(context.Background())
+	if err := cache.Register(fmt.Sprintf(jwksUrl, appID)); err != nil {
 		return nil, err
 	}
-
-	if err := app.refreshJWKSCache(); err != nil {
-		return nil, err
-	}
+	app.jwksCacheSet = jwk.NewCachedSet(cache, jwksUrl)
 
 	return &app, nil
 }

--- a/app.go
+++ b/app.go
@@ -45,7 +45,9 @@ func New(appID string, config *Config) (*App, error) {
 	if err := cache.Register(fmt.Sprintf(jwksUrl, appID)); err != nil {
 		return nil, err
 	}
-	app.jwksCacheSet = jwk.NewCachedSet(cache, jwksUrl)
+
+	app.jwksCacheSet = jwk.NewCachedSet(cache, fmt.Sprintf(jwksUrl, appID))
+	var _ jwk.Set = app.jwksCacheSet
 
 	return &app, nil
 }

--- a/app_test.go
+++ b/app_test.go
@@ -40,14 +40,6 @@ func TestGetApp(t *testing.T) {
 
 }
 
-func TestAppNewJWKSCache(t *testing.T) {
-	psg, err := passage.New(PassageAppID, &passage.Config{
-		APIKey: PassageApiKey, // An API_KEY environment variable is required for testing.
-	})
-	require.Nil(t, err)
-	assert.NotNil(t, psg.JWKS)
-}
-
 // should be run with the -race flag, i.e. `go test -race -run TestAppJWKSCacheWriteConcurrency`
 func TestAppJWKSCacheWriteConcurrency(t *testing.T) {
 	goRoutineCount := 2

--- a/authentication.go
+++ b/authentication.go
@@ -42,14 +42,8 @@ func (a *App) getPublicKey(token *jwt.Token) (interface{}, error) {
 	}
 
 	key, ok := a.JWKS.LookupKeyID(keyID)
-	// if key doesn't exist, re-fetch one more time to see if this jwk was just added
 	if !ok {
 		if err := a.refreshJWKSCache(); err != nil {
-			return nil, err
-		}
-
-		key, ok = a.JWKS.LookupKeyID(keyID)
-		if !ok {
 			return nil, Error{Message: fmt.Sprintf("unable to find key %q", keyID)}
 		}
 	}

--- a/authentication.go
+++ b/authentication.go
@@ -1,7 +1,6 @@
 package passage
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -41,7 +40,7 @@ func (a *App) getPublicKey(token *jwt.Token) (interface{}, error) {
 		return nil, Error{Message: "expecting JWT header to have string kid"}
 	}
 
-	key, ok := a.JWKS.LookupKeyID(keyID)
+	key, ok := a.jwksCacheSet.LookupKeyID(keyID)
 	if !ok {
 		return nil, Error{Message: fmt.Sprintf("unable to find key %q", keyID)}
 	}
@@ -50,15 +49,6 @@ func (a *App) getPublicKey(token *jwt.Token) (interface{}, error) {
 	err := key.Raw(&pubKey)
 
 	return pubKey, err
-}
-
-func (a *App) refreshJWKSCache() error {
-	var err error
-	if a.JWKS, err = a.jwksCache.Refresh(context.Background(), fmt.Sprintf(jwksUrl, a.ID)); err != nil {
-		return Error{Message: "failed to fetch jwks"}
-	}
-
-	return nil
 }
 
 // AuthenticateRequestWithCookie fetches a cookie from the request and uses it to authenticate

--- a/authentication.go
+++ b/authentication.go
@@ -43,9 +43,7 @@ func (a *App) getPublicKey(token *jwt.Token) (interface{}, error) {
 
 	key, ok := a.JWKS.LookupKeyID(keyID)
 	if !ok {
-		if err := a.refreshJWKSCache(); err != nil {
-			return nil, Error{Message: fmt.Sprintf("unable to find key %q", keyID)}
-		}
+		return nil, Error{Message: fmt.Sprintf("unable to find key %q", keyID)}
 	}
 
 	var pubKey interface{}


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: remove JWK re-fetch logic
END_COMMIT_OVERRIDE

## What's New?

Removes extra re-fetching call when JWK fails to find keyID on lookup. Refactor includes using `cacheSet` instead of individual cache and set.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context
Acceptance Criteria:
* [x] use JWT libraries to handle JWKS caching instead of doing it manually
* [x] Remove any refetch calls when the initial JWK call fails.
* [x] Return error.
