### PR TITLE
feat: remove unnecessary bool return from new functions

### DIFF
--- a/app_user.go
+++ b/app_user.go
@@ -116,23 +116,22 @@ func (a *appUser) Update(userID string, updateBody UpdateBody) (*PassageUser, er
 }
 
 // Delete deletes a user by their user string
-// returns true on success, false and error on failure (bool, err)
-func (a *appUser) Delete(userID string) (bool, error) {
-	ok, err := a.app.DeleteUser(userID)
-	if err != nil {
+// returns error on failure
+func (a *appUser) Delete(userID string) error {
+	if _, err := a.app.DeleteUser(userID); err != nil {
 		var e Error
 		if errors.As(err, &e) {
-			return ok, PassageError{
+			return PassageError{
 				Message:    e.Message,
 				StatusCode: e.StatusCode,
 				ErrorCode:  e.ErrorCode,
 			}
 		}
 
-		return ok, err
+		return err
 	}
 
-	return ok, nil
+	return nil
 }
 
 // Create receives a CreateUserBody struct, creating a user with provided values
@@ -176,41 +175,39 @@ func (a *appUser) ListDevices(userID string) ([]WebAuthnDevices, error) {
 }
 
 // RevokeDevice gets a user using their userID
-// returns a true success, error on failure
-func (a *appUser) RevokeDevice(userID, deviceID string) (bool, error) {
-	ok, err := a.app.RevokeUserDevice(userID, deviceID)
-	if err != nil {
+// returns error on failure
+func (a *appUser) RevokeDevice(userID, deviceID string) error {
+	if _, err := a.app.RevokeUserDevice(userID, deviceID); err != nil {
 		var e Error
 		if errors.As(err, &e) {
-			return ok, PassageError{
+			return PassageError{
 				Message:    e.Message,
 				StatusCode: e.StatusCode,
 				ErrorCode:  e.ErrorCode,
 			}
 		}
 
-		return ok, err
+		return err
 	}
 
-	return ok, nil
+	return nil
 }
 
 // RevokeRefreshTokens revokes a users refresh tokens
-// returns true on success, error on failure
-func (a *appUser) RevokeRefreshTokens(userID string) (bool, error) {
-	ok, err := a.app.SignOut(userID)
-	if err != nil {
+// returns error on failure
+func (a *appUser) RevokeRefreshTokens(userID string) error {
+	if _, err := a.app.SignOut(userID); err != nil {
 		var e Error
 		if errors.As(err, &e) {
-			return ok, PassageError{
+			return PassageError{
 				Message:    e.Message,
 				StatusCode: e.StatusCode,
 				ErrorCode:  e.ErrorCode,
 			}
 		}
 
-		return ok, err
+		return err
 	}
 
-	return ok, nil
+	return nil
 }

--- a/app_user_test.go
+++ b/app_user_test.go
@@ -394,9 +394,8 @@ func TestDelete(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		result, err := psg.User.Delete(CreatedUser.ID)
+		err = psg.User.Delete(CreatedUser.ID)
 		require.Nil(t, err)
-		assert.Equal(t, result, true)
 	})
 
 	t.Run("Error: unauthorized", func(t *testing.T) {
@@ -405,7 +404,7 @@ func TestDelete(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		_, err = psg.User.Delete(CreatedUser.ID)
+		err = psg.User.Delete(CreatedUser.ID)
 		require.NotNil(t, err)
 		passageUnauthorizedAsserts(t, err)
 	})
@@ -416,7 +415,7 @@ func TestDelete(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		_, err = psg.User.Delete("PassageUserID")
+		err = psg.User.Delete("PassageUserID")
 		require.NotNil(t, err)
 
 		passageUserNotFoundAsserts(t, err)
@@ -468,9 +467,8 @@ func TestRevokeRefreshTokens(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		result, err := psg.User.RevokeRefreshTokens(PassageUserID)
+		err = psg.User.RevokeRefreshTokens(PassageUserID)
 		require.Nil(t, err)
-		assert.Equal(t, result, true)
 	})
 
 	t.Run("Error: unauthorized", func(t *testing.T) {
@@ -479,7 +477,7 @@ func TestRevokeRefreshTokens(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		_, err = psg.User.RevokeRefreshTokens(PassageUserID)
+		err = psg.User.RevokeRefreshTokens(PassageUserID)
 		require.NotNil(t, err)
 		passageUnauthorizedAsserts(t, err)
 	})
@@ -490,7 +488,7 @@ func TestRevokeRefreshTokens(t *testing.T) {
 		})
 		require.Nil(t, err)
 
-		_, err = psg.User.RevokeRefreshTokens("PassageUserID")
+		err = psg.User.RevokeRefreshTokens("PassageUserID")
 		require.NotNil(t, err)
 
 		passageUserNotFoundAsserts(t, err)


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
chore: remove unnecessary bool return from new functions
END_COMMIT_OVERRIDE

## What's New?
The new delete methods will only return error

```
- Passage.User.Delete(userId: string): error
- Passage.User.RevokeDevice(userId: string, deviceId: string): error
- Passage.RevokeRefreshTokens(userID string) error
   
```

<!-- Please include a summary of the changes and the related feature/issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Screenshots (if appropriate):

<!-- Please attach any screenshots that would help illustrate the changes. -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have manually tested my code thoroughly
- [ ] I have added/updated inline documentation for public facing interfaces if relevant
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing integration and unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots about the pull request here. -->
